### PR TITLE
Fix: Null id when ai generates subentity

### DIFF
--- a/backend/my-way/src/main/java/br/ufrn/myway/Controller/RoadmapController/AiRoadmapController.java
+++ b/backend/my-way/src/main/java/br/ufrn/myway/Controller/RoadmapController/AiRoadmapController.java
@@ -1,12 +1,15 @@
 package br.ufrn.myway.Controller.RoadmapController;
 
+import br.ufrn.myway.Model.DTO.Request.RequestFullRoadmapDTO;
 import br.ufrn.myway.Model.DTO.Request.RequestRoadmapDTO;
 import br.ufrn.myway.Model.DTO.Response.ResponseGenerateRoadmapDTO;
+import br.ufrn.myway.Model.DTO.Response.ResponseRoadmapDTO;
 import br.ufrn.myway.Model.Mapper.RoadmapMapper;
 import br.ufrn.myway.Service.RoadmapService.AiRoadmapService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,6 +30,19 @@ public class AiRoadmapController {
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 aiRoadmapService.generateRoadmap(
                     roadmapDTO.mainGoal(), roadmapDTO.description()
+                )
+        );
+    }
+
+    @PostMapping("/gen-and-save/{userId}")
+    public ResponseEntity<ResponseRoadmapDTO> generateAndSaveRoadmap(@RequestBody RequestFullRoadmapDTO roadmapDTO, @PathVariable Long userId) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                roadmapMapper.toResponse(
+                        aiRoadmapService.generateAndSaveRoadmap(
+                                roadmapDTO.mainGoal(),
+                                roadmapDTO.description(),
+                                userId
+                        )
                 )
         );
     }

--- a/backend/my-way/src/main/java/br/ufrn/myway/Model/Mapper/RoadmapMapper.java
+++ b/backend/my-way/src/main/java/br/ufrn/myway/Model/Mapper/RoadmapMapper.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import br.ufrn.myway.Model.DTO.Request.RequestFullRoadmapDTO;
 import br.ufrn.myway.Model.DTO.Request.RequestRoadmapDTO;
+import br.ufrn.myway.Model.DTO.Response.ResponseGenerateRoadmapDTO;
 import br.ufrn.myway.Model.DTO.Response.ResponseRoadmapDTO;
 import br.ufrn.myway.Model.Entities.Roadmap;
 import org.mapstruct.Mapper;
@@ -13,6 +14,7 @@ public interface RoadmapMapper {
     Roadmap toEntity(RequestRoadmapDTO roadMapDTO);
     Roadmap toEntity(ResponseRoadmapDTO roadMapDTO);
     Roadmap toEntity(RequestFullRoadmapDTO roadmapDTO);
+    Roadmap toEntity(ResponseGenerateRoadmapDTO generatedRoadmap);
 
     ResponseRoadmapDTO toResponse(Roadmap roadMap);
 

--- a/backend/my-way/src/main/java/br/ufrn/myway/Service/RoadmapService/AiRoadmapService.java
+++ b/backend/my-way/src/main/java/br/ufrn/myway/Service/RoadmapService/AiRoadmapService.java
@@ -1,20 +1,32 @@
 package br.ufrn.myway.Service.RoadmapService;
 
 import br.ufrn.myway.Model.DTO.Response.ResponseGenerateRoadmapDTO;
+import br.ufrn.myway.Model.Entities.Goal;
+import br.ufrn.myway.Model.Entities.Roadmap;
+import br.ufrn.myway.Model.Entities.StudyTopic;
+import br.ufrn.myway.Model.Entities.User;
+import br.ufrn.myway.Model.Enums.ErrorMessageUtils;
+import br.ufrn.myway.Model.Enums.RoadMapStatus;
+import br.ufrn.myway.Service.BusinessException;
+import br.ufrn.myway.Service.GoalService;
+import br.ufrn.myway.Service.UserService;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Service
 public class AiRoadmapService {
 
-
     @Autowired
     private RoadmapService roadmapService;
 
     @Autowired
-    private ChatClient chatClient;
+    private UserService userService;
+
+    @Autowired
+    private GoalService goalService;
 
     @Autowired
     private ChatModel chatModel;
@@ -28,6 +40,40 @@ public class AiRoadmapService {
                         .param("description", description))
                 .call()
                 .entity(ResponseGenerateRoadmapDTO.class);
+    }
+
+    public Roadmap saveGeneratedRoadmap(Roadmap roadmap, Long userId) {
+        User user = userService.findById(userId);
+        Roadmap firstRoadmapToBeSaved = new Roadmap();
+
+        if (user != null) {
+            firstRoadmapToBeSaved.setUser(roadmap.getUser());
+        } else throw new BusinessException(HttpStatus.NOT_FOUND, ErrorMessageUtils.ERROR_NOT_FOUND.getMessage("User"));
+
+        firstRoadmapToBeSaved.setMainGoal(roadmap.getMainGoal());
+        firstRoadmapToBeSaved.setDescription(roadmap.getDescription());
+        firstRoadmapToBeSaved.setStatus(RoadMapStatus.ACTIVE);
+
+        firstRoadmapToBeSaved = roadmapService.save(firstRoadmapToBeSaved, userId);
+        roadmap.setId(firstRoadmapToBeSaved.getId());
+
+        for (Goal goal : roadmap.getGoals()) {
+
+            Goal firstGoalToBeSaved = new Goal();
+            firstGoalToBeSaved.setRoadmap(roadmap);
+            firstGoalToBeSaved.setRoadmapIndex(goal.getRoadmapIndex());
+            firstGoalToBeSaved.setDescription(goal.getDescription());
+            firstGoalToBeSaved.setName(goal.getName());
+
+            firstGoalToBeSaved = goalService.save(firstGoalToBeSaved, roadmap.getId());
+            goal.setId(firstGoalToBeSaved.getId());
+
+            for (StudyTopic studyTopic : goal.getStudyTopics()) {
+                studyTopic.setGoal(goal);
+            }
+        }
+
+        return roadmapService.save(roadmap, userId);
     }
 
 }

--- a/backend/my-way/src/main/java/br/ufrn/myway/Service/RoadmapService/AiRoadmapService.java
+++ b/backend/my-way/src/main/java/br/ufrn/myway/Service/RoadmapService/AiRoadmapService.java
@@ -6,10 +6,10 @@ import br.ufrn.myway.Model.Entities.Roadmap;
 import br.ufrn.myway.Model.Entities.StudyTopic;
 import br.ufrn.myway.Model.Entities.User;
 import br.ufrn.myway.Model.Enums.ErrorMessageUtils;
-import br.ufrn.myway.Model.Enums.RoadMapStatus;
 import br.ufrn.myway.Model.Mapper.RoadmapMapper;
 import br.ufrn.myway.Service.BusinessException;
 import br.ufrn.myway.Service.GoalService;
+import br.ufrn.myway.Service.StudyTopicService;
 import br.ufrn.myway.Service.UserService;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatModel;
@@ -30,6 +30,9 @@ public class AiRoadmapService {
     private GoalService goalService;
 
     @Autowired
+    private StudyTopicService studyTopicService;
+
+    @Autowired
     private RoadmapMapper roadmapMapper;
 
     @Autowired
@@ -48,32 +51,34 @@ public class AiRoadmapService {
 
     public Roadmap saveGeneratedRoadmap(Roadmap roadmap, Long userId) {
         User user = userService.findById(userId);
-        Roadmap firstRoadmapToBeSaved = new Roadmap();
 
-        if (user != null) {
-            firstRoadmapToBeSaved.setUser(roadmap.getUser());
-        } else throw new BusinessException(HttpStatus.NOT_FOUND, ErrorMessageUtils.ERROR_NOT_FOUND.getMessage("User"));
+        if (user == null)
+            throw new BusinessException(HttpStatus.NOT_FOUND, ErrorMessageUtils.ERROR_NOT_FOUND.getMessage("User"));
 
-        firstRoadmapToBeSaved.setMainGoal(roadmap.getMainGoal());
-        firstRoadmapToBeSaved.setDescription(roadmap.getDescription());
-        firstRoadmapToBeSaved.setStatus(RoadMapStatus.ACTIVE);
+        Roadmap roadmapToBeSaved = new Roadmap();
+        roadmapToBeSaved.setUser(user);
+        roadmapToBeSaved.setMainGoal(roadmap.getMainGoal());
+        roadmapToBeSaved.setDescription(roadmap.getDescription());
+        roadmapToBeSaved = roadmapService.save(roadmapToBeSaved, userId);
 
-        firstRoadmapToBeSaved = roadmapService.save(firstRoadmapToBeSaved, userId);
-        roadmap.setId(firstRoadmapToBeSaved.getId());
+        roadmap.setUser(user);
+        roadmap.setId(roadmapToBeSaved.getId());
 
         for (Goal goal : roadmap.getGoals()) {
 
-            Goal firstGoalToBeSaved = new Goal();
-            firstGoalToBeSaved.setRoadmap(roadmap);
-            firstGoalToBeSaved.setRoadmapIndex(goal.getRoadmapIndex());
-            firstGoalToBeSaved.setDescription(goal.getDescription());
-            firstGoalToBeSaved.setName(goal.getName());
+            Goal goalToBeSaved = new Goal();
+            goalToBeSaved.setRoadmap(roadmapToBeSaved);
+            goalToBeSaved.setRoadmapIndex(goal.getRoadmapIndex());
+            goalToBeSaved.setDescription(goal.getDescription());
+            goalToBeSaved.setName(goal.getName());
+            goalToBeSaved = goalService.save(goalToBeSaved, roadmapToBeSaved.getId());
 
-            firstGoalToBeSaved = goalService.save(firstGoalToBeSaved, roadmap.getId());
-            goal.setId(firstGoalToBeSaved.getId());
+            goal.setRoadmap(roadmapToBeSaved);
+            goal.setId(goalToBeSaved.getId());
 
             for (StudyTopic studyTopic : goal.getStudyTopics()) {
-                studyTopic.setGoal(goal);
+                studyTopic.setGoal(goalToBeSaved);
+                studyTopicService.save(studyTopic, goalToBeSaved.getId());
             }
         }
 

--- a/backend/my-way/src/main/java/br/ufrn/myway/Service/RoadmapService/AiRoadmapService.java
+++ b/backend/my-way/src/main/java/br/ufrn/myway/Service/RoadmapService/AiRoadmapService.java
@@ -7,6 +7,7 @@ import br.ufrn.myway.Model.Entities.StudyTopic;
 import br.ufrn.myway.Model.Entities.User;
 import br.ufrn.myway.Model.Enums.ErrorMessageUtils;
 import br.ufrn.myway.Model.Enums.RoadMapStatus;
+import br.ufrn.myway.Model.Mapper.RoadmapMapper;
 import br.ufrn.myway.Service.BusinessException;
 import br.ufrn.myway.Service.GoalService;
 import br.ufrn.myway.Service.UserService;
@@ -27,6 +28,9 @@ public class AiRoadmapService {
 
     @Autowired
     private GoalService goalService;
+
+    @Autowired
+    private RoadmapMapper roadmapMapper;
 
     @Autowired
     private ChatModel chatModel;
@@ -74,6 +78,14 @@ public class AiRoadmapService {
         }
 
         return roadmapService.save(roadmap, userId);
+    }
+
+    public Roadmap generateAndSaveRoadmap(String mainGoal, String description, Long userId) {
+        ResponseGenerateRoadmapDTO generatedRoadmap = generateRoadmap(mainGoal, description);
+
+        return saveGeneratedRoadmap(
+                roadmapMapper.toEntity(generatedRoadmap), userId
+        );
     }
 
 }

--- a/backend/my-way/src/main/java/br/ufrn/myway/Service/RoadmapService/RoadmapService.java
+++ b/backend/my-way/src/main/java/br/ufrn/myway/Service/RoadmapService/RoadmapService.java
@@ -33,7 +33,7 @@ public class RoadmapService {
 
     public Roadmap save(Roadmap roadmap, Long id) {
         User user = userService.findById(id);
-        if (user != null) {
+        if (roadmap.getUser() == null) {
             roadmap.setUser(user);
         }
         if (roadmap.getStatus() == null) {

--- a/backend/my-way/src/main/java/br/ufrn/myway/Service/RoadmapService/RoadmapService.java
+++ b/backend/my-way/src/main/java/br/ufrn/myway/Service/RoadmapService/RoadmapService.java
@@ -33,7 +33,7 @@ public class RoadmapService {
 
     public Roadmap save(Roadmap roadmap, Long id) {
         User user = userService.findById(id);
-        if (user == null) {
+        if (user != null) {
             roadmap.setUser(user);
         }
         if (roadmap.getStatus() == null) {


### PR DESCRIPTION
## 📌 Descrição

> Ao salvar um roadmap gerado por IA no endpoint de atualização normal, os IDs das sub-entidades estavam sendo setados como null.

O que foi feito?  
- Correção do bug acima através do método saveGeneratedRoadmap, que salva cada entidade individualmente, setando os IDs de forma apropriada;
- Também foi feito um endpoint para centralizar a geração e a persistência do roadmap recém gerado em uma única requisição;

<!-- Descreva o que foi feito neste PR -->

## 🚀 Tipo de mudança

- [ ] Nova funcionalidade (feat)
- [x] Correção de bug (fix)
- [ ] Refatoração
- [ ] Atualização de documentação
- [ ] Outro (especifique):

## 📋 Checklist

- [ ] Testes adicionados/atualizados
- [ ] Documentação atualizada (se aplicável)
- [ ] PR relacionado à uma Issue existente
- [x] Código passou nos testes locais

## 🧪 Como testar

Postman ou similar
<!-- Descreva os passos para testar essa PR -->
